### PR TITLE
Enable Input field for Browser Console

### DIFF
--- a/docs/TESTPLAN.md
+++ b/docs/TESTPLAN.md
@@ -71,6 +71,7 @@ curl -X POST ${SERVER}/buckets/main/collections/${CID}/records \
 ```
 
 - Start firefox
+- Enable the "Enable browser chrome and addon-debugging toolboxes" switch in devtools settings.
 - Open the browser console using Firefox's top menu at `Tools > Web Developer > Browser Console`
 - Run the following in the browser console:
 


### PR DESCRIPTION
The Browser Console does not have an input field by default.

You have to go into DevTools, go into Settings (F1) and enable the checkbox for "Enable browser chrome and addon-debugging toolboxes"