### PR TITLE
renamed cfr-ml-model to cfr-ml-models

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -101,11 +101,11 @@ const everyRun = async () => {
     const alarmListener = async alarm => {
       if (alarm.name === periodicAlarmName) {
         console.info(
-          `Fetching "cfr-ml-model" bucket contents directly from the remote settings server endpoint`,
+          `Fetching "cfr-ml-models" bucket contents directly from the remote settings server endpoint`,
         );
-        // Imports models from remote settings (`cfr-ml-model` bucket)
+        // Imports models from remote settings (`cfr-ml-models` bucket)
         const cfrMlModelsCollectionRecords = await browser.privileged.remoteSettings.fetchFromEndpointDirectly(
-          "cfr-ml-model",
+          "cfr-ml-models",
         );
         await onModelUpdate(cfrMlModelsCollectionRecords);
       }

--- a/src/privileged/messagingSystem/api.js
+++ b/src/privileged/messagingSystem/api.js
@@ -174,9 +174,9 @@ this.messagingSystem = class extends ExtensionAPI {
               const listener = async (...args) => {
                 await fire.async(...args);
               };
-              RemoteSettings("cfr-ml-model").on("sync", listener);
+              RemoteSettings("cfr-ml-models").on("sync", listener);
               return () => {
-                RemoteSettings("cfr-ml-model").off("sync", listener);
+                RemoteSettings("cfr-ml-models").off("sync", listener);
               };
             },
           }).api(),

--- a/src/privileged/remoteSettings/api.js
+++ b/src/privileged/remoteSettings/api.js
@@ -14,7 +14,7 @@ Cu.importGlobalProperties(["fetch"]);
 const allowListedCollections = [
   "cfr-ml-control",
   "cfr-ml-experiments",
-  "cfr-ml-model",
+  "cfr-ml-models",
 ];
 
 this.remoteSettings = class extends ExtensionAPI {


### PR DESCRIPTION
I renamed all instances of `cfr-ml-model` to `cfr-ml-models`

The collection was mis-named because I incorrectly filed the ticket with the pluralized named when we created the collection in stage and prod. See: https://bugzilla.mozilla.org/show_bug.cgi?id=1601303

Rename in this repository was done by issuing: 

```sh
find . -name "*.js"|xargs sed  -i ".bak" "s/cfr-ml-model/cfr-ml-models/"
```