### PR TITLE
Fix for #21

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messaging-system-personalization-experiment-1-addon",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "messaging-system-personalization-experiment-1-addon",
   "private": true,
   "license": "MPLv2",

--- a/src/clientContext.js
+++ b/src/clientContext.js
@@ -229,10 +229,15 @@ const getClientContext = async () => {
     "Merging with model inputs from clientContext web extension experiment API",
   );
 
+  safe_total_uri_count = await browser.privileged.clientContext.getTotalUriCount();
+  if (safe_total_uri_count === undefined) {
+    safe_total_uri_count = 0;
+  }
+
   return {
     has_firefox_as_default_browser: asRouterTargetingGetters.isDefaultBrowser,
     active_ticks: await browser.privileged.clientContext.getActiveTicks(),
-    total_uri_count: await browser.privileged.clientContext.getTotalUriCount(),
+    total_uri_count: safe_total_uri_count,
     about_preferences_non_default_value_count: await browser.privileged.clientContext.getAboutPreferencesNonDefaultValueCount(),
     self_installed_addons_count: listOfSelfInstalledEnabledAddons.length,
     self_installed_popular_privacy_security_addons_count:

--- a/src/clientContext.js
+++ b/src/clientContext.js
@@ -229,15 +229,10 @@ const getClientContext = async () => {
     "Merging with model inputs from clientContext web extension experiment API",
   );
 
-  safe_total_uri_count = await browser.privileged.clientContext.getTotalUriCount();
-  if (safe_total_uri_count === undefined) {
-    safe_total_uri_count = 0;
-  }
-
   return {
     has_firefox_as_default_browser: asRouterTargetingGetters.isDefaultBrowser,
     active_ticks: await browser.privileged.clientContext.getActiveTicks(),
-    total_uri_count: safe_total_uri_count,
+    total_uri_count: await browser.privileged.clientContext.getTotalUriCount() || 0,
     about_preferences_non_default_value_count: await browser.privileged.clientContext.getAboutPreferencesNonDefaultValueCount(),
     self_installed_addons_count: listOfSelfInstalledEnabledAddons.length,
     self_installed_popular_privacy_security_addons_count:

--- a/src/uploadEvaluatedFeatures.js
+++ b/src/uploadEvaluatedFeatures.js
@@ -81,6 +81,14 @@ const uploadEvaluatedFeatures = async (
     addClientId,
     addEnvironment: false,
   };
+
+  if (payload.client_context_features.total_uri_count === 0) {
+    // In some cases - the total_uri_count returned from 
+    // browser.privileged.clientContext.getTotalUriCount() returns an
+    // `undefined`.   In those cases, we just skip the current ping.
+    console.log(`Skipped due to missing total_uri_count: "${telemetryTopic}" telemetry:`, payload);
+    return;
+  }
   await browser.telemetry.submitPing(type, message, options);
   console.log(`Submitted "${telemetryTopic}" telemetry:`, payload);
 };


### PR DESCRIPTION
WIP : not tested yet

This fix is split into two parts.

1. Override undefined total_uri_count value to 0

The acquisition of the total_uri_count in the
clientContext so that a check for undefined can be performed.

In that case, I've overwritten the total_uri_count to be 0.

2.  Secondary check after schema validation

The schema validation should now pass as the total_uri_count is always
at least zero.

Just prior to submitting the ping, the total_uri_count is now checked
and if it is a zero - the ping is dropped.  This seems better than
sending up a bogus value.